### PR TITLE
exportMDContent 不导出yfm

### DIFF
--- a/src/api/kernel-api.ts
+++ b/src/api/kernel-api.ts
@@ -430,7 +430,8 @@ class KernelApi extends BaseApi {
 
   public async exportMDContent(blockID: string) {
     const params = {
-      "id": blockID
+      "id": blockID,
+      "yfm": false
     };
     return await this.siyuanRequest("/api/export/exportMdContent", params);
   }


### PR DESCRIPTION
我这里直接在api里设置yfm=false了
如果有需要的人，或许可以在设置里添加是否导出yfm，不过我觉得大多数人其实是不需要yfm的