### PR TITLE
fix: exclude nested docs from literature title refresh

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "main": ".src/index.js",
   "scripts": {
     "lint": "eslint . --fix --cache",
-    "test": "npm run test:attr-view",
+    "test": "npm run test:attr-view && npm run test:literature-doc-query",
     "test:attr-view": "ts-node --transpile-only --project tsconfig.test.json tests/attrViewConfig.test.ts",
+    "test:literature-doc-query": "ts-node --transpile-only --project tsconfig.test.json tests/literatureDocQuery.test.ts",
     "dev": "webpack --mode development",
     "build": "webpack --mode production"
   },

--- a/src/api/kernel-api.ts
+++ b/src/api/kernel-api.ts
@@ -24,6 +24,7 @@
  */
 
 import { BaseApi, type SiyuanData } from "./base-api";
+import { buildLiteratureDocInPathStatement } from "./literature-doc-query";
 import { siyuanApiToken, siyuanApiUrl } from "../utils/constants";
 import { fetchPost } from "siyuan";
 /**
@@ -240,19 +241,7 @@ class KernelApi extends BaseApi {
 
   public async getLiteratureDocInPath(notebook: string, dir_hpath: string, offset: number, limit: number): Promise<SiyuanData> {
     const params = {
-      "stmt": `SELECT 
-          b.id, b.root_id, b.box, b."path", b.hpath, b.name, b.content, a.value as literature_key, c.value as literature_unlink
-        FROM blocks b 
-          left outer join (
-            select * FROM "attributes" WHERE name = "custom-literature-key"
-          ) as a on b.id = a.block_id 
-          left outer join (
-            select * FROM "attributes" WHERE name = "custom-literature-unlinked"
-          ) as c on b.id = c.block_id 
-        WHERE 
-          b.box like '${notebook}' and 
-          b.hpath like '${dir_hpath}%' and 
-          b.type like 'd' limit ${limit}, ${offset}`
+      "stmt": buildLiteratureDocInPathStatement(notebook, dir_hpath, offset, limit)
     };
     return await this.siyuanRequest("/api/query/sql", params);
   }

--- a/src/api/literature-doc-query.ts
+++ b/src/api/literature-doc-query.ts
@@ -1,0 +1,54 @@
+function normalizeDirectoryHPath(dirHPath: string): string {
+  const trimmed = dirHPath.trim();
+  if (!trimmed || trimmed === "/") return "/";
+  return `${trimmed.replace(/\/+$/, "")}/`;
+}
+
+function escapeSqlString(value: string): string {
+  return value.replace(/'/g, "''");
+}
+
+function normalizeNonNegativeInteger(value: number, fallback: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : fallback;
+}
+
+export function isDirectChildDocument(dirHPath: string, documentHPath: string): boolean {
+  if (typeof documentHPath !== "string") return false;
+  const prefix = normalizeDirectoryHPath(dirHPath);
+  if (!documentHPath.startsWith(prefix)) return false;
+  const relativePath = documentHPath.slice(prefix.length);
+  return relativePath.length > 0 && !relativePath.includes("/");
+}
+
+export function buildLiteratureDocInPathStatement(
+  notebook: string,
+  dirHPath: string,
+  offset: number,
+  limit: number,
+): string {
+  const prefix = normalizeDirectoryHPath(dirHPath);
+  const escapedNotebook = escapeSqlString(notebook);
+  const escapedPrefix = escapeSqlString(prefix);
+  const prefixLength = prefix.length;
+  const relativePathStart = prefixLength + 1;
+  const safeOffset = normalizeNonNegativeInteger(offset, 0);
+  const safeLimit = Math.max(1, normalizeNonNegativeInteger(limit, 64));
+
+  return `SELECT
+          b.id, b.root_id, b.box, b."path", b.hpath, b.name, b.content, a.value as literature_key, c.value as literature_unlink
+        FROM blocks b
+          left outer join (
+            select * FROM "attributes" WHERE name = "custom-literature-key"
+          ) as a on b.id = a.block_id
+          left outer join (
+            select * FROM "attributes" WHERE name = "custom-literature-unlinked"
+          ) as c on b.id = c.block_id
+        WHERE
+          b.box = '${escapedNotebook}' and
+          substr(b.hpath, 1, ${prefixLength}) = '${escapedPrefix}' and
+          length(substr(b.hpath, ${relativePathStart})) > 0 and
+          instr(substr(b.hpath, ${relativePathStart}), '/') = 0 and
+          b.type = 'd'
+        ORDER BY b.hpath, b.id
+        LIMIT ${safeLimit} OFFSET ${safeOffset}`;
+}

--- a/src/utils/util.ts
+++ b/src/utils/util.ts
@@ -4,6 +4,7 @@ import {
   STORAGE_NAME
 } from "./constants";
 import { createLogger } from "./simple-logger";
+import { isDirectChildDocument } from "../api/literature-doc-query";
 import { type INoticer } from "./noticer";
 
 interface ReadDirRes {
@@ -82,11 +83,13 @@ export async function loadLocalRef(plugin: SiYuanPluginCitation): Promise<LoadLo
        * 2. key在文档的命名中
        * 3. key在文档的自定义字段“custom-literature-key”中
        */
-      const literatureDocs  = (await plugin.kernelApi.getLiteratureDocInPath(notebookId, refPath + "/", offset, limit)).data as any[];
-      if (literatureDocs.length < limit) {
+      const queriedDocs = (await plugin.kernelApi.getLiteratureDocInPath(notebookId, refPath, offset, limit)).data as any[];
+      if (queriedDocs.length < limit) {
         // 已经提取到所有了
         cont = false;
       }
+      // SQL 已限制为直接子文档；这里再做一次防御性过滤，避免后端方言或路径异常把更深层子文档带入文献池。
+      const literatureDocs = queriedDocs.filter(file => isDirectChildDocument(refPath, file.hpath));
       const pList = literatureDocs.map(async file => {
         let key = "";
         const literatureKey = file.literature_key;

--- a/tests/literatureDocQuery.test.ts
+++ b/tests/literatureDocQuery.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+
+import {
+  buildLiteratureDocInPathStatement,
+  isDirectChildDocument,
+} from "../src/api/literature-doc-query";
+
+const tests: Array<[string, () => void]> = [];
+function test(name: string, run: () => void) {
+  tests.push([name, run]);
+}
+
+test("only direct children of the literature library are accepted", () => {
+  const libraryPath = "/Assets/References";
+  assert.equal(isDirectChildDocument(libraryPath, "/Assets/References/Paper A"), true);
+  assert.equal(isDirectChildDocument(`${libraryPath}/`, "/Assets/References/Paper B"), true);
+  assert.equal(isDirectChildDocument(libraryPath, "/Assets/References/Paper A/Notes"), false);
+  assert.equal(isDirectChildDocument(libraryPath, "/Assets/References/Paper A/Notes/Draft"), false);
+  assert.equal(isDirectChildDocument(libraryPath, "/Assets/References-Archive/Paper A"), false);
+  assert.equal(isDirectChildDocument(libraryPath, "/Assets/References/"), false);
+  assert.equal(isDirectChildDocument(libraryPath, undefined as any), false);
+});
+
+test("root libraries still distinguish direct and nested documents", () => {
+  assert.equal(isDirectChildDocument("/", "/Paper A"), true);
+  assert.equal(isDirectChildDocument("/", "/Paper A/Notes"), false);
+});
+
+test("the query selects a stable, paginated set of direct children", () => {
+  const statement = buildLiteratureDocInPathStatement(
+    "box'quoted",
+    "/Assets/References/",
+    128,
+    64,
+  );
+
+  assert.match(statement, /b\.box = 'box''quoted'/);
+  assert.match(statement, /substr\(b\.hpath, 1, 19\) = '\/Assets\/References\/'/);
+  assert.match(statement, /length\(substr\(b\.hpath, 20\)\) > 0/);
+  assert.match(statement, /instr\(substr\(b\.hpath, 20\), '\/'\) = 0/);
+  assert.match(statement, /ORDER BY b\.hpath, b\.id/);
+  assert.match(statement, /LIMIT 64 OFFSET 128/);
+});
+
+test("pagination values are normalized", () => {
+  const statement = buildLiteratureDocInPathStatement("box", "/References", -2.5, 0);
+  assert.match(statement, /LIMIT 1 OFFSET 0/);
+});
+
+let passed = 0;
+for (const [name, run] of tests) {
+  try {
+    run();
+    passed++;
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    console.error(`✗ ${name}`);
+    throw error;
+  }
+}
+console.log(`${passed}/${tests.length} literature document query tests passed`);


### PR DESCRIPTION
Closes #150

## 修复内容

- 文献池查询只返回“文献库”文档的直接子文档，不再把文献内容文档下面的子文档视作文献。
- 使用明确的 `LIMIT ... OFFSET ...` 和稳定排序，保证分页结果无重复、无遗漏。
- 在客户端增加直接子文档防御性过滤，避免后端 SQL 方言或异常路径重新引入深层文档。
- 对笔记本 ID 和路径进行 SQL 字符串转义。
- 新增路径层级、根目录、SQL 结构和分页参数测试。

## 验证

- `npm test`：14/14 通过（原数据库属性测试 10 个 + 本修复测试 4 个）。
- `npm run build`：生产构建通过，仅有项目现存的包体积/Svelte 配置警告。
- 当前文献库只读分页验证：9 页、539 条、539 个唯一 ID、0 个深层文档。
- 在一个包含两层子文档的真实目录上匿名只读对照：旧查询返回 4 条，新查询只返回 2 条直接子文档，正确排除 2 条更深层文档。
- 修复产物部署后重新加载思源，citation 插件无启动错误。

为避免对真实文献执行批量重命名，本次没有点击“刷新所有文献内容文档标题”。